### PR TITLE
Make parsing of NIDQ fles more robust

### DIFF
--- a/feldman_lab_to_nwb/convert_feldman/convert_feldman.py
+++ b/feldman_lab_to_nwb/convert_feldman/convert_feldman.py
@@ -25,6 +25,11 @@ lfp_data_file = raw_data_file.parent / raw_data_file.name.replace("ap", "lf")
 behavior_folder_path = base_path / "ADRIAN"
 nidq_synch_file = str(raw_data_path / raw_session_name / f"{raw_session_name}_t0.nidq.bin")
 
+# Necesssary information for decoding the nidq synchronization correctly
+# These are the indices of the channels in the nidq_synch_file responsible for tracking the two streams
+trial_ongoing_channel = 2
+event_channel = 5
+
 # Enter Session and Subject information here - uncomment any fields you want to include
 session_description = "Enter session description here."
 # session_start_time = datetime(1970, 1, 1)  # not necessary if writing raw recording data (SpikeGLX sets it)
@@ -52,7 +57,11 @@ source_data = dict(
 conversion_options = dict(
     SpikeGLXRecording=dict(stub_test=stub_test),
     SpikeGLXLFP=dict(stub_test=stub_test),
-    Behavior=dict(nidq_synch_file=nidq_synch_file)
+    Behavior=dict(
+        nidq_synch_file=nidq_synch_file,
+        trial_ongoing_channel=trial_ongoing_channel,
+        event_channel=event_channel
+    )
 )
 converter = FeldmanNWBConverter(source_data=source_data)
 metadata = converter.get_metadata()

--- a/feldman_lab_to_nwb/convert_feldman/feldman_utils.py
+++ b/feldman_lab_to_nwb/convert_feldman/feldman_utils.py
@@ -5,7 +5,7 @@ import numpy as np
 from spikeextractors import SpikeGLXRecordingExtractor
 
 
-def get_trials_info(recording_nidq: SpikeGLXRecordingExtractor, trial_ongoing_channel: int = 3, event_channel: int = 4):
+def get_trials_info(recording_nidq: SpikeGLXRecordingExtractor, trial_ongoing_channel: int, event_channel: int):
     """
     Parse trial number, stimulus number, and segment number for each trial.
 

--- a/feldman_lab_to_nwb/convert_feldman/feldmanbehaviordatainterface.py
+++ b/feldman_lab_to_nwb/convert_feldman/feldmanbehaviordatainterface.py
@@ -33,14 +33,23 @@ class FeldmanBehaviorDataInterface(BaseDataInterface):
         metadata = dict(NWBFile=dict(session_id=header_data["ExptName"].values[0]))
         return metadata
 
-    def run_conversion(self, nwbfile: NWBFile, metadata: dict, nidq_synch_file: str):
+    def run_conversion(
+        self,
+        nwbfile: NWBFile,
+        metadata: dict,
+        nidq_synch_file: str,
+        trial_ongoing_channel: int,
+        event_channel: int
+    ):
         """
         Primary conversion function for the custom Feldman lab behavioral interface.
 
         Uses the synch information in the nidq_synch_file to set trial times in NWBFile.
         """
         (trial_numbers, stimulus_numbers, segment_numbers_from_nidq, trial_times_from_nidq) = get_trials_info(
-            recording_nidq=SpikeGLXRecordingExtractor(file_path=nidq_synch_file)
+            recording_nidq=SpikeGLXRecordingExtractor(file_path=nidq_synch_file),
+            trial_ongoing_channel=trial_ongoing_channel,
+            event_channel=event_channel
         )
 
         folder_path = Path(self.source_data["folder_path"])

--- a/notebooks/parse-nidq-signals.ipynb
+++ b/notebooks/parse-nidq-signals.ipynb
@@ -17,6 +17,7 @@
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
     "from pprint import pprint\n",
+    "from tqdm import tqdm\n",
     "\n",
     "import spikeextractors as se\n",
     "import spiketoolkit as st\n",
@@ -35,17 +36,10 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "# base_path = Path(\"D:/Feldman\")\n",
-    "# #base_path = Path(\"/Users/abuccino/Documents/Data/catalyst/brody/A256_bank1_2020_09_30_g0\")\n",
-    "# #base_data_path = Path(\"D:/Neuropixels/Neuropixels/A256_bank1_2020_09_30/A256_bank1_2020_09_30_g0\")\n",
-    "# base_data_path = Path(\"20210115_NPX_and_behavior/2021_01_15_E105/towersTask_g0\")\n",
-    "# ap_bin_path = base_data_path / \"towersTask_g0_imec0\" / \"towersTask_g0_t0.imec0.ap.bin\"\n",
-    "# lf_bin_path = base_data_path / \"towersTask_g0_imec0\" / \"towersTask_g0_t0.imec0.lf.bin\""
+    "## 210209/LR_210209_2_g1"
    ]
   },
   {
@@ -54,7 +48,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "base_path = Path(\"/Users/abuccino/Documents/Data/catalyst/feldman/\")\n",
+    "# base_path = Path(\"/Users/abuccino/Documents/Data/catalyst/feldman/210406/\")\n",
+    "base_path = Path(\"/Users/abuccino/Documents/Data/catalyst/feldman/210209/\")\n",
     "session_name = \"LR_210209_2_g1\"\n",
     "ap_bin_path = base_path / session_name / f\"{session_name}_imec0\" / f\"{session_name}_t0.imec0.ap.bin\"\n",
     "nidq_bin_path = base_path / session_name / f\"{session_name}_t0.nidq.bin\""
@@ -67,6 +62,34 @@
    "outputs": [],
    "source": [
     "recording_nidq = se.SpikeGLXRecordingExtractor(nidq_bin_path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "trial_ongoing_channel = 3\n",
+    "event_channel = 4"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "traces_events = recording_nidq.get_traces(channel_ids=[event_channel])[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "np.max(traces_events * (16 - 1) / (4.5 * 1e6))"
    ]
   },
   {
@@ -163,16 +186,7 @@
    "outputs": [],
    "source": [
     "# AI 1-2-7 - not used\n",
-    "_ = sw.plot_timeseries(recording_nidq, channel_ids=[1, 2, 7], trange=[0, 120])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from tqdm import tqdm"
+    "_ = sw.plot_timeseries(recording_nidq, channel_ids=[0, trial_ongoing_channel, event_channel] , trange=[0, 120])"
    ]
   },
   {
@@ -234,6 +248,17 @@
     "    t_start_idxs = np.where(np.diff(tr_trial_bin) > 0)[0]\n",
     "    t_stop_idxs = np.where(np.diff(tr_trial_bin) < 0)[0]\n",
     "    \n",
+    "    # discard first stop event if it comes before a start event\n",
+    "    if t_stop_idxs[0] < t_start_idxs[0]:\n",
+    "        print(\"Discarding first trial\")\n",
+    "        t_stop_idxs = t_stop_idxs[1:]\n",
+    "        \n",
+    "    # discard last start event if it comes after last stop event\n",
+    "    if t_start_idxs[-1] > t_stop_idxs[-1]:\n",
+    "        print(\"Discarding last trial\")\n",
+    "        t_start_idxs = t_start_idxs[:-1]\n",
+    "        \n",
+    "    \n",
     "    assert len(t_start_idxs) == len(t_stop_idxs), \"Found a different number of trial start and trial stop indices\"\n",
     "    \n",
     "    trial_numbers = []\n",
@@ -256,7 +281,7 @@
     "        # First 4 digits (10ms each) are the trial number\n",
     "        for i in range(4):\n",
     "            median_value = np.median(tr_events[i_start + 10:i_start + tenms_interval - 10])\n",
-    "            digit = int(np.round(median_value * (hex_base - 1) / voltage_range))\n",
+    "            digit = int(np.floor(median_value * (hex_base - 1) / voltage_range))\n",
     "            trial_digits += hex_dict[digit]\n",
     "            i_start += tenms_interval\n",
     "        trial_numbers.append(int(trial_digits, hex_base))        \n",
@@ -264,7 +289,7 @@
     "        # Second 4 digits (10ms each) are the stimulus number\n",
     "        for i in range(4):\n",
     "            median_value = np.median(tr_events[i_start + 10:i_start + tenms_interval - 10])\n",
-    "            digit = int(np.round(median_value * (hex_base - 1) / voltage_range))\n",
+    "            digit = int(np.floor(median_value * (hex_base - 1) / voltage_range))\n",
     "            stimulus_digits += hex_dict[digit]\n",
     "            i_start += tenms_interval\n",
     "        stimulus_numbers.append(int(stimulus_digits, hex_base))        \n",
@@ -272,7 +297,7 @@
     "        # Third 4 digits (10ms each) are the segment number\n",
     "        for i in range(4):\n",
     "            median_value = np.median(tr_events[i_start + 10:i_start + tenms_interval - 10])\n",
-    "            digit = int(np.round(median_value * (hex_base - 1) / voltage_range))\n",
+    "            digit = int(np.floor(median_value * (hex_base - 1) / voltage_range))\n",
     "            segment_digits += hex_dict[digit]\n",
     "            i_start += tenms_interval\n",
     "        segment_numbers.append(int(segment_digits, hex_base))        \n",
@@ -287,8 +312,8 @@
    "outputs": [],
    "source": [
     "trial_numbers, stimulus_numbers, segment_numbers, trial_times = get_trials_info(recording_nidq, \n",
-    "                                                                                trial_ongoing_channel=3, \n",
-    "                                                                                event_channel=4)"
+    "                                                                                trial_ongoing_channel=trial_ongoing_channel, \n",
+    "                                                                                event_channel=event_channel)"
    ]
   },
   {
@@ -305,6 +330,213 @@
    "metadata": {},
    "source": [
     "Now we just need to write this info to NWB!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 210406/LR_210406_g0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# base_path = Path(\"/Users/abuccino/Documents/Data/catalyst/feldman/210406/\")\n",
+    "base_path = Path(\"/Users/abuccino/Documents/Data/catalyst/feldman/210406/\")\n",
+    "session_name = \"LR_210406_g0\"\n",
+    "ap_bin_path = base_path / session_name / f\"{session_name}_imec0\" / f\"{session_name}_t0.imec0.ap.bin\"\n",
+    "nidq_bin_path = base_path / session_name / f\"{session_name}_t0.nidq.bin\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "recording_nidq = se.SpikeGLXRecordingExtractor(nidq_bin_path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "trial_ongoing_channel = 2\n",
+    "event_channel = 3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "duration = recording_nidq.get_num_frames() / recording_nidq.get_sampling_frequency()\n",
+    "print(duration)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "_ = sw.plot_timeseries(recording_nidq, channel_ids=[0, trial_ongoing_channel, event_channel] , trange=[2000, 2120])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "trial_numbers, stimulus_numbers, segment_numbers, trial_times = get_trials_info(recording_nidq, \n",
+    "                                                                                trial_ongoing_channel=trial_ongoing_channel, \n",
+    "                                                                                event_channel=event_channel)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 210217/LRKV_210217_g1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# base_path = Path(\"/Users/abuccino/Documents/Data/catalyst/feldman/210406/\")\n",
+    "base_path = Path(\"/Users/abuccino/Documents/Data/catalyst/feldman/210217/\")\n",
+    "session_name = \"LRKV_210217_g1\"\n",
+    "ap_bin_path = base_path / session_name / f\"{session_name}_imec0\" / f\"{session_name}_t0.imec0.ap.bin\"\n",
+    "nidq_bin_path = base_path / session_name / f\"{session_name}_t0.nidq.bin\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "recording_nidq = se.SpikeGLXRecordingExtractor(nidq_bin_path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "trial_ongoing_channel = 2\n",
+    "event_channel = 3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "duration = recording_nidq.get_num_frames() / recording_nidq.get_sampling_frequency()\n",
+    "print(duration)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "_ = sw.plot_timeseries(recording_nidq, channel_ids=[0, trial_ongoing_channel, event_channel] , trange=[0, 30])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "trial_numbers, stimulus_numbers, segment_numbers, trial_times = get_trials_info(recording_nidq, \n",
+    "                                                                                trial_ongoing_channel=trial_ongoing_channel, \n",
+    "                                                                                event_channel=event_channel)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 210217/LRKV_210217_g2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# base_path = Path(\"/Users/abuccino/Documents/Data/catalyst/feldman/210406/\")\n",
+    "base_path = Path(\"/Users/abuccino/Documents/Data/catalyst/feldman/210217/\")\n",
+    "session_name = \"LRKV_210217_g2\"\n",
+    "ap_bin_path = base_path / session_name / f\"{session_name}_imec0\" / f\"{session_name}_t0.imec0.ap.bin\"\n",
+    "nidq_bin_path = base_path / session_name / f\"{session_name}_t0.nidq.bin\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "recording_nidq = se.SpikeGLXRecordingExtractor(nidq_bin_path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "trial_ongoing_channel = 2\n",
+    "event_channel = 3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "duration = recording_nidq.get_num_frames() / recording_nidq.get_sampling_frequency()\n",
+    "print(duration)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "_ = sw.plot_timeseries(recording_nidq, channel_ids=[0, trial_ongoing_channel, event_channel] , trange=[200, 300])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "trial_numbers, stimulus_numbers, segment_numbers, trial_times = get_trials_info(recording_nidq, \n",
+    "                                                                                trial_ongoing_channel=trial_ongoing_channel, \n",
+    "                                                                                event_channel=event_channel)"
    ]
   }
  ],


### PR DESCRIPTION
After testing with all recordings, the following updates were made:

- instead of `np.round`, use `np.floor` to ensure parsed hex data is 0-15 
- discard forst or last trial in case of a mismatch between start and end time events

Note that for `210217/LRKV_210217_g1`, `210217/LRKV_210217_g2` and `210406/LR_210406_g0`, `trial_ongoing_channel = 2` and `event_channel = 3`