### PR TITLE
Clip recording condition

### DIFF
--- a/feldman_lab_to_nwb/convert_feldman/convert_feldman.py
+++ b/feldman_lab_to_nwb/convert_feldman/convert_feldman.py
@@ -10,26 +10,28 @@ from feldman_lab_to_nwb import FeldmanNWBConverter
 base_path = Path("E:/Feldman")
 
 # Name the NWBFile and point to the desired save path
-nwbfile_path = base_path / "LR_210209_g0_full_sorted_testing_with_second_sync_attempt_behavior.nwb"
+nwbfile_path = base_path / "LR_210406_g0_full_pipeline_stub_test.nwb"
 
 # Point to the various files for the conversion
-experiment_folder = base_path / "Neuropixels_Feldman" / "210209"
-session_name = "LR_210209_g0"
+session_date = "210406"  # YYMMDD
+experiment_folder = base_path / "Neuropixels_Feldman" / f"{session_date}"
+
+behavior_folder_path = experiment_folder / "IGOR"
+
+sess_name = f"LR_{session_date}_g0"
 raw_data_file = (
-    experiment_folder / "SpikeGLX" / session_name / f"{session_name}_imec0" / f"{session_name}_t0.imec0.ap.bin"
+    experiment_folder / "SpikeGLX" / sess_name/ f"{sess_name}_imec0" / f"{sess_name}_t0.imec0.ap.bin"
 )
 lfp_data_file = raw_data_file.parent / raw_data_file.name.replace("ap", "lf")
-behavior_folder_path = experiment_folder / "ADRIAN"
-nidq_synch_file = str(experiment_folder / "SpikeGLX" / session_name / f"{session_name}_t0.nidq.bin")
+nidq_synch_file = str(experiment_folder / "SpikeGLX" / sess_name / f"{sess_name}_t0.nidq.bin")
 
 # Necesssary information for decoding the nidq synchronization correctly
 # These are the indices of the channels in the nidq_synch_file responsible for tracking the two streams
 trial_ongoing_channel = 2
-event_channel = 5
+event_channel = 3
 
 # Enter Session and Subject information here - uncomment any fields you want to include
 session_description = "Enter session description here."
-session_start_time = datetime(1970, 1, 1)  # not necessary if writing raw recording data (SpikeGLX sets it)
 
 # All the subject fields are optional, but included for detail
 subject_info = dict(
@@ -48,20 +50,21 @@ overwrite = True  # 'True' replaces the file if it exists, 'False' appends it wi
 
 # Run the conversion
 source_data = dict(
-    # SpikeGLXRecording=dict(file_path=str(raw_data_file)),
-    # SpikeGLXLFP=dict(file_path=str(lfp_data_file)),
+    SpikeGLXRecording=dict(file_path=str(raw_data_file)),
+    SpikeGLXLFP=dict(file_path=str(lfp_data_file)),
     Behavior=dict(folder_path=str(behavior_folder_path))
 )
 conversion_options = dict(
     SpikeGLXRecording=dict(stub_test=stub_test),
     SpikeGLXLFP=dict(stub_test=stub_test),
-    Behavior=dict(
-        nidq_synch_file=nidq_synch_file,
-        trial_ongoing_channel=trial_ongoing_channel,
-        event_channel=event_channel
-    )
+    Behavior=dict()
 )
-converter = FeldmanNWBConverter(source_data=source_data)
+converter = FeldmanNWBConverter(
+    source_data=source_data,
+    nidq_synch_file=nidq_synch_file,
+    trial_ongoing_channel=trial_ongoing_channel,
+    event_channel=event_channel
+)
 metadata = converter.get_metadata()
 metadata["NWBFile"].update(session_description=session_description)
 metadata.update(Subject=subject_info)

--- a/feldman_lab_to_nwb/convert_feldman/feldmanbehaviordatainterface.py
+++ b/feldman_lab_to_nwb/convert_feldman/feldmanbehaviordatainterface.py
@@ -205,7 +205,7 @@ class FeldmanBehaviorDataInterface(BaseDataInterface):
             trial_data.loc[:, "Laser"] = trial_data.loc[:, "Laser"].astype(bool)
             last_trial = 0
             m = 0
-            for j, trial, offset in enumerate(zip(stimulus_data.loc[:, "Trial"], stimulus_data.loc[:, "Time_ms"])):
+            for j, (trial, offset) in enumerate(zip(stimulus_data.loc[:, "Trial"], stimulus_data.loc[:, "Time_ms"])):
                 if trial == last_trial:
                     m += 1
                 else:

--- a/feldman_lab_to_nwb/convert_feldman/feldmanbehaviordatainterface.py
+++ b/feldman_lab_to_nwb/convert_feldman/feldmanbehaviordatainterface.py
@@ -1,18 +1,14 @@
 """Authors: Cody Baker."""
 from pandas import DataFrame, read_csv
 from pathlib import Path
-from warnings import warn
-import re
 import numpy as np
 from typing import Dict, Iterable
 
-from ndx_events import AnnotatedEventsTable
 from nwb_conversion_tools.basedatainterface import BaseDataInterface
-from nwb_conversion_tools.utils.conversion_tools import get_module
 from pynwb import NWBFile
 from spikeextractors import SpikeGLXRecordingExtractor
 
-from .feldman_utils import get_trials_info
+from .feldman_utils import get_trials_info, clip_trials
 
 
 def add_trial_columns(
@@ -43,8 +39,7 @@ def add_trial_columns(
 
 def add_trials(
     nwbfile: NWBFile,
-    trial_starts: Iterable[float],
-    trial_stops: Iterable[float],
+    trial_times: Iterable[Iterable[float]],
     header_data: DataFrame,
     trial_data: DataFrame,
     stimulus_data: DataFrame,
@@ -63,7 +58,7 @@ def add_trials(
     )
 
     for n, k in enumerate(range(int(header_data["FirstTrialNum"]), int(header_data["LastTrialNum"]))):
-        trial_kwargs = dict(start_time=trial_starts[n], stop_time=trial_stops[n])
+        trial_kwargs = dict(start_time=trial_times[k][0], stop_time=trial_times[k][1])
         for csv_column_name, trial_column_name in trial_csv_column_names.items():
             trial_kwargs.update({trial_column_name: trial_data[csv_column_name][n]})
 
@@ -94,9 +89,12 @@ class FeldmanBehaviorDataInterface(BaseDataInterface):
     @classmethod
     def get_source_schema(cls):
         return dict(
-            required=['folder_path'],
+            required=["folder_path", "nidq_synch_file", "trial_ongoing_channel", "event_channel"],
             properties=dict(
-                folder_path=dict(type='string')
+                folder_path=dict(type="string"),
+                nidq_synch_file=dict(type="string"),
+                trial_ongoing_channel=dict(type="number"),
+                event_channel=dict(type="number"),
             )
         )
 
@@ -107,14 +105,7 @@ class FeldmanBehaviorDataInterface(BaseDataInterface):
         metadata = dict(NWBFile=dict(session_id=header_data["ExptName"].values[0]))
         return metadata
 
-    def run_conversion(
-        self,
-        nwbfile: NWBFile,
-        metadata: dict,
-        nidq_synch_file: str,
-        trial_ongoing_channel: int,
-        event_channel: int
-    ):
+    def run_conversion(self, nwbfile: NWBFile, metadata: dict):
         """
         Primary conversion function for the custom Feldman lab behavioral interface.
 
@@ -122,14 +113,17 @@ class FeldmanBehaviorDataInterface(BaseDataInterface):
         """
         folder_path = Path(self.source_data["folder_path"])
 
-        (trial_numbers, stimulus_numbers, segment_numbers_from_nidq, trial_times_from_nidq) = get_trials_info(
-            recording_nidq=SpikeGLXRecordingExtractor(file_path=nidq_synch_file),
-            trial_ongoing_channel=trial_ongoing_channel,
-            event_channel=event_channel
+        trial_numbers, stimulus_numbers, trial_times_from_nidq = get_trials_info(
+            recording_nidq=SpikeGLXRecordingExtractor(file_path=self.source_data["nidq_synch_file"]),
+            trial_ongoing_channel=self.source_data["trial_ongoing_channel"],
+            event_channel=self.source_data["event_channel"]
+        )
+        trial_numbers, stimulus_numbers, trial_times_from_nidq = clip_trials(
+            trial_numbers=trial_numbers,
+            stimulus_numbers=stimulus_numbers,
+            trial_times=trial_times_from_nidq
         )
         header_segments = [x for x in folder_path.iterdir() if "header" in x.name]
-        assert len(header_segments) == len(set(segment_numbers_from_nidq)), \
-            "Mismatch between number of segments extracted from nidq file and number of header.csv files!"
 
         exclude_columns = set(["TrNum", "Segment", "ISS0Time", "Arm0Time"])
         trial_csv_column_names = dict(
@@ -185,26 +179,21 @@ class FeldmanBehaviorDataInterface(BaseDataInterface):
             stimulus_probabilities="Probability that the stimulus was presented; 0 if deterministic.",
             stimulus_piezo_labels="Manually assigned labels to each stimulus element."
         )
-        # last_end_time = 0  # shift value for later segments
+        add_trial_columns(
+            nwbfile=nwbfile,
+            trial_csv_column_names=trial_csv_column_names,
+            trial_csv_column_descriptions=trial_csv_column_descriptions,
+            stimulus_column_names=stimulus_column_description.keys(),
+            stimulus_column_description=stimulus_column_description,
+            exclude_columns=exclude_columns
+        )
+        last_end_time = 0  # shift value for later segments
         for header_segment in header_segments:
             header_data = read_csv(header_segment, header=None, sep="\t", index_col=0).T
             trial_data = read_csv(str(header_segment).replace("header", "trials"), header=0, sep="\t")
             if trial_data["TrStartTime"].iloc[-1] == 0 and trial_data["TrEndTime"].iloc[-1] == 0:
-                trial_data.drop(index=-1)
+                trial_data.drop(trial_data.index[-1], inplace=True)
             stimulus_data = read_csv(str(header_segment).replace("header", "stimuli"), header=0, sep="\t")
-
-            segment_number = header_data["SegmentNum"]
-            p = re.compile("_S(\d+)_")
-            res = p.search(header_segment.name)
-            if res is not None and segment_number.values[0] != res.group(1):
-                warn(
-                    f"Segment number in file name ({header_segment.name}) does not match internal value! "
-                    "Using file name."
-                )
-            segment_number_from_file_name = int(res.group(1))
-            seg_index = segment_numbers_from_nidq == segment_number_from_file_name
-            segment_trial_start_times = trial_times_from_nidq[seg_index, 0]
-            segment_trial_stop_times = trial_times_from_nidq[seg_index, 1]
 
             trial_segment_csv_start_times = np.array(trial_data.loc[:, "TrStartTime"])
             for csv_column in trial_data:
@@ -212,23 +201,14 @@ class FeldmanBehaviorDataInterface(BaseDataInterface):
                     trial_data.loc[:, csv_column] = (
                         (
                             np.array(trial_data.loc[:, csv_column]) - trial_segment_csv_start_times
-                        ) / 1e3 + segment_trial_start_times
+                        ) / 1e3 + last_end_time
                     )
             trial_data.loc[:, "Laser"] = trial_data.loc[:, "Laser"].astype(bool)
-            stimulus_data.loc[:, "Time_ms"] = stimulus_data.loc[:, "Time_ms"] / 1e3 + segment_trial_start_times
+            stimulus_data.loc[:, "Time_ms"] = stimulus_data.loc[:, "Time_ms"] / 1e3 + last_end_time
 
-            add_trial_columns(
-                nwbfile=nwbfile,
-                trial_csv_column_names=trial_csv_column_names,
-                trial_csv_column_descriptions=trial_csv_column_descriptions,
-                stimulus_column_names=stimulus_column_description.keys(),
-                stimulus_column_description=stimulus_column_description,
-                exclude_columns=exclude_columns
-            )
             add_trials(
                 nwbfile=nwbfile,
-                trial_starts=segment_trial_start_times,
-                trial_stops=segment_trial_stop_times,
+                trial_times=trial_times_from_nidq,
                 trial_data=trial_data,
                 stimulus_data=stimulus_data,
                 header_data=header_data,

--- a/feldman_lab_to_nwb/convert_feldman/feldmannwbconverter.py
+++ b/feldman_lab_to_nwb/convert_feldman/feldmannwbconverter.py
@@ -32,12 +32,13 @@ class FeldmanNWBConverter(NWBConverter):
             trial_ongoing_channel=trial_ongoing_channel,
             event_channel=event_channel
         )
-        for interface in set(["SpikeGLXRecording", "SpikeGLXLFP"]).intersection(self.data_interface_objects):
-            self.data_interface_objects[interface].recording_extractor = clip_recording(
-                trial_numbers=trial_numbers,
-                trial_times=trial_times,
-                recording=self.data_interface_objects[interface].recording_extractor
-            )
+        if trial_numbers[0] != 0:
+            for interface in set(["SpikeGLXRecording", "SpikeGLXLFP"]).intersection(self.data_interface_objects):
+                self.data_interface_objects[interface].recording_extractor = clip_recording(
+                    trial_numbers=trial_numbers,
+                    trial_times=trial_times,
+                    recording=self.data_interface_objects[interface].recording_extractor
+                )
 
     def get_metadata(self):
         behavior_folder_path = Path(self.data_interface_objects["Behavior"].source_data["folder_path"])

--- a/feldman_lab_to_nwb/convert_feldman/feldmannwbconverter.py
+++ b/feldman_lab_to_nwb/convert_feldman/feldmannwbconverter.py
@@ -1,9 +1,13 @@
 """Authors: Cody Baker."""
 from pathlib import Path
+from typing import Optional
 
+from pynwb import NWBFile
+from spikeextractors import SpikeGLXRecordingExtractor
 from nwb_conversion_tools import NWBConverter, SpikeGLXRecordingInterface, SpikeGLXLFPInterface
 
-# from .feldmanbehaviordatainterface import FeldmanBehaviorDataInterface
+from .feldmanbehaviordatainterface import FeldmanBehaviorDataInterface
+from .feldman_utils import get_trials_info, clip_recording
 
 
 class FeldmanNWBConverter(NWBConverter):
@@ -12,8 +16,28 @@ class FeldmanNWBConverter(NWBConverter):
     data_interface_classes = dict(
         SpikeGLXRecording=SpikeGLXRecordingInterface,
         SpikeGLXLFP=SpikeGLXLFPInterface,
-        # Behavior=FeldmanBehaviorDataInterface
+        Behavior=FeldmanBehaviorDataInterface
     )
+
+    def __init__(self, source_data: dict, nidq_synch_file: str, trial_ongoing_channel: int, event_channel: int):
+        if "Behavior" in source_data:
+            source_data["Behavior"].update(
+                nidq_synch_file=nidq_synch_file,
+                trial_ongoing_channel=trial_ongoing_channel,
+                event_channel=event_channel
+            )
+        super().__init__(source_data=source_data)
+        trial_numbers, _, trial_times = get_trials_info(
+            recording_nidq=SpikeGLXRecordingExtractor(nidq_synch_file),
+            trial_ongoing_channel=trial_ongoing_channel,
+            event_channel=event_channel
+        )
+        for interface in set(["SpikeGLXRecording", "SpikeGLXLFP"]).intersection(self.data_interface_objects):
+            self.data_interface_objects[interface].recording_extractor = clip_recording(
+                trial_numbers=trial_numbers,
+                trial_times=trial_times,
+                recording=self.data_interface_objects[interface].recording_extractor
+            )
 
     def get_metadata(self):
         behavior_folder_path = Path(self.data_interface_objects["Behavior"].source_data["folder_path"])

--- a/feldman_lab_to_nwb/convert_feldman/feldmannwbconverter.py
+++ b/feldman_lab_to_nwb/convert_feldman/feldmannwbconverter.py
@@ -1,8 +1,6 @@
 """Authors: Cody Baker."""
 from pathlib import Path
-from typing import Optional
 
-from pynwb import NWBFile
 from spikeextractors import SpikeGLXRecordingExtractor
 from nwb_conversion_tools import NWBConverter, SpikeGLXRecordingInterface, SpikeGLXLFPInterface
 

--- a/notebooks/processing_pipeline.ipynb
+++ b/notebooks/processing_pipeline.ipynb
@@ -114,6 +114,29 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Synchronize recording times with trials"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "trial_numbers, _, trial_times = get_trials_info(\n",
+    "    recording_nidq=SpikeGLXRecordingExtractor(nidq_synch_file),\n",
+    "    trial_ongoing_channel=trial_ongoing_channel,\n",
+    "    event_channel=event_channel\n",
+    ")\n",
+    "if trial_numbers[0] != 0:\n",
+    "    recording_ap = clip_recording(trial_numbers=trial_numbers, trial_times=trial_times, recording=recording_ap)\n",
+    "    recording_lf = clip_recording(trial_numbers=trial_numbers, trial_times=trial_times, recording=recording_lf)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Inspect signals"
    ]
   },
@@ -717,7 +740,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.1"
+   "version": "3.8.8"
   },
   "pycharm": {
    "stem_cell": {

--- a/notebooks/rapid_testing_pipeline.ipynb
+++ b/notebooks/rapid_testing_pipeline.ipynb
@@ -66,7 +66,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "recording_ap = SpikeGLXRecordingExtractor(ap_bin_path)"
+    "recording_ap = SpikeGLXRecordingExtractor(ap_bin_path)\n",
+    "trial_numbers, _, trial_times = get_trials_info(\n",
+    "    recording_nidq=SpikeGLXRecordingExtractor(nidq_synch_file),\n",
+    "    trial_ongoing_channel=trial_ongoing_channel,\n",
+    "    event_channel=event_channel\n",
+    ")\n",
+    "if trial_numbers[0] != 0:\n",
+    "    recording_ap = clip_recording(trial_numbers=trial_numbers, trial_times=trial_times, recording=recording_ap)"
    ]
   },
   {
@@ -253,7 +260,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.1"
+   "version": "3.8.8"
   },
   "pycharm": {
    "stem_cell": {


### PR DESCRIPTION
@bendichter Fixes two issues.

The first, how to handle the case where the early section of the recording, as decoded from the nidq preceeds behavioral tracking. E.g., nidq trials begin in the hundreds or thousands, then reset to 0 at the indicated time the behavior system starts tracking this experimental session.

The second, extracting and aligning behavioral timing information from the csv's across multiple segments (previously, there was a shift value between each segment that was unknown). Now all time information is aligned to the nidq stream by default, even over the later segments.