### PR TITLE
Map nwbfile to spikes.mat format

### DIFF
--- a/feldman_lab_to_nwb/convert_feldman/convert_feldman.py
+++ b/feldman_lab_to_nwb/convert_feldman/convert_feldman.py
@@ -48,8 +48,8 @@ overwrite = True  # 'True' replaces the file if it exists, 'False' appends it wi
 
 # Run the conversion
 source_data = dict(
-    # SpikeGLXRecording=dict(file_path=str(raw_data_file)),
-    # SpikeGLXLFP=dict(file_path=str(lfp_data_file)),
+    SpikeGLXRecording=dict(file_path=str(raw_data_file)),
+    SpikeGLXLFP=dict(file_path=str(lfp_data_file)),
     Behavior=dict(folder_path=str(behavior_folder_path))
 )
 conversion_options = dict(

--- a/feldman_lab_to_nwb/convert_feldman/feldman_utils.py
+++ b/feldman_lab_to_nwb/convert_feldman/feldman_utils.py
@@ -337,7 +337,7 @@ def convert_nwb_to_spikes_mat(
                 StimTime_Unwrapped=[y for x in nwbfile.trials.stimulus_times[()] for y in x]
             )
         )
-        header_info = json.load(nwbfile.session_description)["header_info"]
+        header_info = json.load(nwbfile.trials.description)  # Assumes this was made by the FeldmanBehaviorInterface
         n_trials = len(nwbfile.trials.id)
         for x, y in header_info.items():
             out_dict["attributes"]["stimuli"].update({x: [y] * n_trials})

--- a/feldman_lab_to_nwb/convert_feldman/feldman_utils.py
+++ b/feldman_lab_to_nwb/convert_feldman/feldman_utils.py
@@ -209,13 +209,16 @@ def convert_nwb_to_spikes_mat(
         spike_trials = np.array([0] * out_dict["spikes"]["nspikes"])
         spike_times_in_trials = np.array([0] * out_dict["spikes"]["nspikes"])
         trial = 0
+        trial_start_time = trials.start_time[()]
+        trial_stop_time = trials.stop_time[()]
         for j, spike_time in enumerate(out_dict["spikes"]["acq_times"]):
-            while spike_time > trials["stop_time"][trial] and trial < n_trials:
+            while spike_time > trial_stop_time[trial] and trial < n_trials:
                 trial += 1
             spike_trials[j] = trial + 1
-            spike_times_in_trials[j] = spike_time - trials["start_time"][trial]
+            spike_times_in_trials[j] = spike_time - trial_start_time[trial]
 
-        sampling_frequency = nwbfile.units.sampling_frequency
+        acquisition_name = list(nwbfile.acquisition)[0]
+        sampling_frequency = nwbfile.acquisition[acquisition_name].rate
         parameters = json.loads(nwbfile.units.description)  # Assumes this was made by the Feldman processing pipeline
         filter_parameters = parameters["filter_parameters"]
         sorter_parameters = parameters["sorter_parameters"]
@@ -223,23 +226,27 @@ def convert_nwb_to_spikes_mat(
 
         waveforms = []
         channel_locations = np.array(
-            [[x, y] for x, y in zip(nwbfile.electrodes.rel_x.data, nwbfile.electrodes.rel_y.data)]
+            [[x, y] for x, y in zip(nwbfile.electrodes.rel_x[()], nwbfile.electrodes.rel_y[()])]
         )
         channel_ids = np.array(nwbfile.electrodes.id)
         for spike_index in units.spike_times_indexes:
-            spike_frame = round(spike_time/sampling_frequency)
+            spike_frame = round(spike_time / sampling_frequency)
             max_channel = nwbfile.units.max_channel[spike_index]
             channel_distances = np.linalg.norm(channel_locations - channel_locations[max_channel], axis=1)
             closest_channels = channel_ids[np.argsort(channel_distances)]
             waveforms.append(
-                nwbfile.acquisition[list(nwbfile.acquisition)[0]].data[
+                nwbfile.acquisition[acquisition_name].data[
                     spike_frame:spike_frame+n_waveform_samples,
                     closest_channels[:n_waveform_channels]
                 ]
             )
 
+        assigns = []
+        for unit, idx_range in zip(nwbfile.units.id[()], nwbfile.units.spike_time_index.data[()]):
+            assigns.extend([unit] * idx_range)
+
         out_dict["spikes"].update(
-            assigns=units.spike_times_indexes,
+            assigns=assigns,
             att_fname=nwbfile_path.absolute(),
             info=dict(),
             labels=[list(range(1, n_units + 1)), list(range(1, n_units + 1))],
@@ -247,7 +254,7 @@ def convert_nwb_to_spikes_mat(
             params=sorter_parameters,
             spiketimes=spike_times_in_trials,
             trials=spike_trials,
-            unwrapped_times=units.spike_times[()] - trials["start_time"][0],
+            unwrapped_times=units.spike_times[()] - trial_start_time[0],
             waveforms=waveforms
         )
 
@@ -256,52 +263,36 @@ def convert_nwb_to_spikes_mat(
         piezo_order = np.argsort(unique_piezo)
         piezo_numbers = unique_piezo[piezo_order]
         out_dict["attributes"].update(
-            SweepOnsetSorting=dict(),
-            RewardOnset=nwbfile.trials.reward_start_time,
-            GNG=nwbfile.trials.stimulus_gngs,
-            TrLaser=nwbfile.trials.laser_is_on,
+            SweepOnsetSorting=[],
+            RewardOnset=nwbfile.trials.reward_start_time[()],
+            GNG=nwbfile.trials.stimulus_gngs[()],
+            TrLaser=nwbfile.trials.laser_is_on[()],
             sweep_table=dict(
-                TrNum=1,
-                Segment=1,
-                ISS0Time=1,
-                Arm0Time=1,
-                TrStartTime=1,
-                TrEndTime=1,
-                RWStartTime=1,
-                RWEndTime=1,
-                StimOnsetTime=1,
-                StimNum=1,
-                Tone=1,
-                TrType=1,
-                LickInWindow=1,
-                TrOutcome=1,
-                RewardTime=1,
-                NLicks=1,
-                CumNRewards=1,
-                CumVol=1,
-                StimLayout=1,
-                StimOrder=1,
-                Laser=1,
-                SegmentNum=1,
-                Iss0time=1,  # duplicate
+                TrNum=nwbfile.trials.id[()],
+                StimNum=nwbfile.trials.stimulus_number[()],
+                ISS0Time=nwbfile.trials.ISS0Time[()],
+                Iss0time=nwbfile.trials.ISS0Time[()],  # duplicate
+                Arm0Time=nwbfile.trials.Arm0Time[()],
+                TrStartTime=nwbfile.trials.start_time[()],
+                TrEndTime=nwbfile.trials.stop_time[()],
+                RWStartTime=nwbfile.trials.reward_start_time[()],
+                RWEndTime=nwbfile.trials.reward_stop_time[()],
+                Tone=nwbfile.trials.tone[()],
+                TrType=nwbfile.trials.trial_type[()],
+                LickInWindow=nwbfile.trials.licks_in_window[()],
+                TrOutcome=nwbfile.trials.trial_outcome[()],
+                RewardTime=nwbfile.trials.reward_time[()],
+                NLicks=nwbfile.trials.number_of_licks[()],
+                CumNRewards=nwbfile.trials.cumulative_rewards[()],
+                CumVol=nwbfile.trials.cumulative_volume[()],
+                StimOrder=nwbfile.trials.stimulus_order[()],
+                Laser=nwbfile.trials.laser_is_on[()],
                 FirstTrialNum=1,
                 LastTrialNum=1,
-                Nstimuli=1,
-                ArduinoMode=1,
-                ITImean=1,
-                ITIrange=1,
-                MaxLicksLimit=1,
-                RewardCalib_b=1,
-                RewardCalib_m=1,
-                UseGlobalGNG=1,
-                A=1,
-                B=1,
-                # ...=1,
-                Z=1,
-                Nelements=1,
-                PiezoLabel0=1,
-                # ...=1,
-                PieazoLabel18=1,
+                StimOnsetTime=1,
+                StimLayout=1,
+                Segment=1,
+                SegmentNum=1,
             ),
             experiment=dict(
                 Index=1,
@@ -310,7 +301,7 @@ def convert_nwb_to_spikes_mat(
                 Genotype=nwbfile.subject.genotype,
                 Age=nwbfile.subject.age,
                 Rec_Num=1,
-                Whiskers=list(set(nwbfile.trials.stimulus_piezo_labels))[piezo_order],
+                Whiskers=list(set(nwbfile.trials.stimulus_piezo_labels[()]))[piezo_order],
                 Piezo_Numbers=piezo_numbers,
                 Piezo_distance=2500,
                 Weight_Percent=100,
@@ -325,27 +316,29 @@ def convert_nwb_to_spikes_mat(
                 ]
             ),
             stimuli=dict(
-                Trial=[x for x, y in zip(nwbfile.trials.id, nwbfile.trials.stimulus_elements) for _ in y],
-                Posn=[y for x in nwbfile.trials.stimulus_ordinalities for y in x],
-                StimElem=nwbfile.trials.stimulus_number,
-                Time_ms=[z - x for x, y in zip(nwbfile.trials.start_time, nwbfile.trials.stimulus_elements) for z in y],
-                Ampl=[1] * len(nwbfile.trials.stimulus_number),
-                ElemPiezo=[y for x in nwbfile.trials.stimulus_elements for y in x],
-                ElemAmp=[y for x in nwbfile.trials.stimulus_amplitudes for y in x],
-                ElemProb=[y for x in nwbfile.trials.stimulus_probabilities for y in x],
-                ElemDur=[y for x in nwbfile.trials.stimulus_durations for y in x],
-                ElemShape=[y for x in nwbfile.trials.stimulus_shapes for y in x],
-                ElemRise=[y for x in nwbfile.trials.stimulus_rises for y in x],
-                ElemGNG=[y for x in nwbfile.trials.stimulus_gngs for y in x],
-                MW_Tone=nwbfile.trials.tone,
-                MW_Laser=nwbfile.trials.laser_is_on,
-                WhiskerID=nwbfile.trials.stimulus_piezo_labels,
-                StimTime_Unwrapped=[y for x in nwbfile.trials.stimulus_times for y in x]
+                Trial=[x for x, y in zip(nwbfile.trials.id[()], nwbfile.trials.stimulus_elements[()]) for _ in y],
+                Posn=[y for x in nwbfile.trials.stimulus_ordinalities[()] for y in x],
+                StimElem=nwbfile.trials.stimulus_number[()],
+                Time_ms=[z - x for x, y in zip(
+                    nwbfile.trials.start_time[()],
+                    nwbfile.trials.stimulus_elements[()]
+                ) for z in y],
+                Ampl=[1] * len(nwbfile.trials.stimulus_number[()]),
+                ElemPiezo=[y for x in nwbfile.trials.stimulus_elements[()] for y in x],
+                ElemAmp=[y for x in nwbfile.trials.stimulus_amplitudes[()] for y in x],
+                ElemProb=[y for x in nwbfile.trials.stimulus_probabilities[()] for y in x],
+                ElemDur=[y for x in nwbfile.trials.stimulus_durations[()] for y in x],
+                ElemShape=[y for x in nwbfile.trials.stimulus_shapes[()] for y in x],
+                ElemRise=[y for x in nwbfile.trials.stimulus_rises[()] for y in x],
+                ElemGNG=[y for x in nwbfile.trials.stimulus_gngs[()] for y in x],
+                MW_Tone=nwbfile.trials.tone[()],
+                MW_Laser=nwbfile.trials.laser_is_on[()],
+                WhiskerID=nwbfile.trials.stimulus_piezo_labels[()],
+                StimTime_Unwrapped=[y for x in nwbfile.trials.stimulus_times[()] for y in x]
             )
         )
-        out_dict["stimuli"].update(
-            MW_RelAmp=out_dict["stimuli"]["ElemAmp"],
-            MW_Prob=out_dict["stimuli"]["ElemProb"],
-            MW_GNG=out_dict["stimuli"]["ElemGNG"]
-        )
+        header_info = json.load(nwbfile.session_description)["header_info"]
+        n_trials = len(nwbfile.trials.id)
+        for x, y in header_info.items():
+            out_dict["attributes"]["stimuli"].update({x: [y] * n_trials})
         savemat(file_name=str(matfile_path), mdict=out_dict)

--- a/feldman_lab_to_nwb/convert_feldman/feldman_utils.py
+++ b/feldman_lab_to_nwb/convert_feldman/feldman_utils.py
@@ -1,8 +1,12 @@
 """Authors: Alessio Buccino and Cody Baker."""
 from tqdm import tqdm
 import numpy as np
+from pathlib import Path
+from typing import Union
 
 from spikeextractors import SpikeGLXRecordingExtractor
+
+PathType = Union[str, Path]
 
 
 def get_trials_info(recording_nidq: SpikeGLXRecordingExtractor, trial_ongoing_channel: int = 3, event_channel: int = 4):
@@ -99,3 +103,8 @@ def get_trials_info(recording_nidq: SpikeGLXRecordingExtractor, trial_ongoing_ch
         segment_numbers.append(int(segment_digits, hex_base))
 
     return np.array(trial_numbers), np.array(stimulus_numbers), np.array(segment_numbers), np.array(trial_times)
+
+
+def convert_nwb_to_spikes_mat(nwbfile_path: PathType):
+    pass
+

--- a/feldman_lab_to_nwb/convert_feldman/feldmanbehaviordatainterface.py
+++ b/feldman_lab_to_nwb/convert_feldman/feldmanbehaviordatainterface.py
@@ -6,6 +6,7 @@ from typing import Dict, Iterable
 
 from nwb_conversion_tools.basedatainterface import BaseDataInterface
 from pynwb import NWBFile
+from pynwb.file import TrialTable
 from spikeextractors import SpikeGLXRecordingExtractor
 
 from .feldman_utils import get_trials_info, clip_trials
@@ -127,6 +128,11 @@ class FeldmanBehaviorDataInterface(BaseDataInterface):
             trial_times=trial_times_from_nidq
         )
         header_segments = [x for x in folder_path.iterdir() if "header" in x.name]
+        first_header = read_csv(header_segments[0], header=None, sep="\t", index_col=0).T
+        nwbfile.trials = TrialTable(
+            name="trials",
+            description=str({x: y.values[0] for x, y in first_header.items()}).replace("'", "\"")
+        )
 
         exclude_columns = set(["TrNum", "Segment", "ISS0Time", "Arm0Time"])
         trial_csv_column_names = dict(

--- a/feldman_lab_to_nwb/convert_feldman/feldmanbehaviordatainterface.py
+++ b/feldman_lab_to_nwb/convert_feldman/feldmanbehaviordatainterface.py
@@ -6,10 +6,10 @@ from typing import Dict, Iterable
 
 from nwb_conversion_tools.basedatainterface import BaseDataInterface
 from pynwb import NWBFile
-from pynwb.file import TrialTable
+from pynwb.file import TimeIntervals
 from spikeextractors import SpikeGLXRecordingExtractor
 
-from .feldman_utils import get_trials_info, clip_trials
+from .utils import get_trials_info, clip_trials
 
 
 def add_trial_columns(
@@ -129,12 +129,12 @@ class FeldmanBehaviorDataInterface(BaseDataInterface):
         )
         header_segments = [x for x in folder_path.iterdir() if "header" in x.name]
         first_header = read_csv(header_segments[0], header=None, sep="\t", index_col=0).T
-        nwbfile.trials = TrialTable(
+        nwbfile.trials = TimeIntervals(
             name="trials",
             description=str({x: y.values[0] for x, y in first_header.items()}).replace("'", "\"")
         )
 
-        exclude_columns = set(["TrNum", "Segment", "ISS0Time", "Arm0Time"])
+        exclude_columns = set(["TrNum", "Segment"])
         trial_csv_column_names = dict(
             StimNum="stimulus_number",
             StimLayout="stimulus_layout",
@@ -171,7 +171,9 @@ class FeldmanBehaviorDataInterface(BaseDataInterface):
             LickInWindow="Number of licks in selected window.",
             Laser="Boolean indicating laser activity.",
             CumVol="Cumulative volume.",
-            CumNRewards="Cumulative number of rewards."
+            CumNRewards="Cumulative number of rewards.",
+            ISS0Time="Data needed for spikes.mat roundtrip.",
+            Arm0Time="Data needed for spikes.mat roundtrip."
         )
         stimulus_csv_column_names = dict(
             Time_ms="stimulus_times",

--- a/feldman_lab_to_nwb/convert_feldman/feldmanbehaviordatainterface.py
+++ b/feldman_lab_to_nwb/convert_feldman/feldmanbehaviordatainterface.py
@@ -144,7 +144,9 @@ class FeldmanBehaviorDataInterface(BaseDataInterface):
             LickInWindow="licks_in_window",
             Laser="laser_is_on",
             CumVol="cumulative_volume",
-            CumNRewards="cumulative_number_of_rewards"
+            CumNRewards="cumulative_number_of_rewards",
+            ISS0Time="ISS0Time",
+            Arm0Time="Arm0Time"
         )
         trial_csv_column_descriptions = dict(
             StimNum="The identifier value for stimulus type.",

--- a/feldman_lab_to_nwb/convert_feldman/feldmanbehaviordatainterface.py
+++ b/feldman_lab_to_nwb/convert_feldman/feldmanbehaviordatainterface.py
@@ -6,9 +6,7 @@ import re
 import numpy as np
 from typing import Dict, Iterable
 
-from ndx_events import AnnotatedEventsTable
 from nwb_conversion_tools.basedatainterface import BaseDataInterface
-from nwb_conversion_tools.utils.conversion_tools import get_module
 from pynwb import NWBFile
 from spikeextractors import SpikeGLXRecordingExtractor
 
@@ -61,6 +59,9 @@ def add_trials(
         stimulus_probabilities=np.array([int(header_data[f"ElemProb{x}"]) for x in range(n_elements)]),
         stimulus_piezo_labels=np.array([str(header_data[f"PiezoLabel{x}"].values[0]) for x in range(n_elements)])
     )
+
+    # Extra columns for each special header layout. Technically adding it all to the trials table is very inefficient.
+    # But necessary for the final mapping to the Spikes.mat
 
     for n, k in enumerate(range(int(header_data["FirstTrialNum"]), int(header_data["LastTrialNum"]))):
         trial_kwargs = dict(start_time=trial_starts[n], stop_time=trial_stops[n])
@@ -155,18 +156,18 @@ class FeldmanBehaviorDataInterface(BaseDataInterface):
                 "The index of the stimulus layout. 1=Std, 2=Trains, 3=IL, 4=Trains+IL, 5=RFMap, 6=2WC, 7=MWS, 8=MWD"
             ),
             StimOnsetTime="The time the stimulus was presented.",
-            StimOrder="",
-            Tone="",
+            StimOrder="Index of stimulus ordering.",
+            Tone="Index of the tone.",
             TrOutcome="The outcome index for each trial.",
             TrType="The type index for each trial.",
-            RewardTime="",
-            RWStartTime="",
-            RWEndTime="",
-            NLicks="",
-            LickInWindow="",
-            Laser="",
-            CumVol="",
-            CumNRewards=""
+            RewardTime="Index of reward timing.",
+            RWStartTime="Times when reward began.",
+            RWEndTime="Times when reward ended.",
+            NLicks="Number of licks.",
+            LickInWindow="Number of licks in selected window.",
+            Laser="Boolean indicating laser activity.",
+            CumVol="Cumulative volume.",
+            CumNRewards="Cumulative number of rewards."
         )
         stimulus_csv_column_names = dict(
             Time_ms="stimulus_times",
@@ -176,11 +177,11 @@ class FeldmanBehaviorDataInterface(BaseDataInterface):
         stimulus_column_description = dict(
             stimulus_elements="Type index of each stimulus element.",
             stimulus_times="Time of occurrence of each stimulus element.",
-            stimulus_amplitudes="",
+            stimulus_amplitudes="Amplitudes for each stimulus element. Unknown units.",
             stimulus_ordinalities="Ordinal position of the stimulus element in the train.",
-            stimulus_rises="",
-            stimulus_gngs="",
-            stimulus_shapes="",
+            stimulus_rises="Rises for each stimulus element. Unknown units.",
+            stimulus_gngs="GNGs for the stimulus element. Unknown units.",
+            stimulus_shapes="Shape index of the stimulus element.",
             stimulus_durations="Duration of the stimulus element in seconds.",
             stimulus_probabilities="Probability that the stimulus was presented; 0 if deterministic.",
             stimulus_piezo_labels="Manually assigned labels to each stimulus element."

--- a/feldman_lab_to_nwb/convert_feldman/feldmannwbconverter.py
+++ b/feldman_lab_to_nwb/convert_feldman/feldmannwbconverter.py
@@ -45,15 +45,4 @@ class FeldmanNWBConverter(NWBConverter):
         metadata["NWBFile"].update(institution="UC Berkeley", lab="Feldman")
         if "session_id" not in metadata["NWBFile"]:
             metadata["NWBFile"].update(session_id="_".join(next(behavior_folder_path.iterdir()).stem.split("_")[:3]))
-
-        header_segments = [x for x in behavior_folder_path.iterdir() if "header" in x.name]
-        first_header = read_csv(header_segments[0], header=None, sep="\t", index_col=0).T
-        metadata["NWBFile"].update(
-            session_description=str(
-                dict(
-                    text_description=metadata["NWBFile"]["session_description"],
-                    header_info={x: y.values[0] for x, y in first_header.items()}
-                )
-            ).replace("'", "\"")
-        )
         return metadata

--- a/feldman_lab_to_nwb/convert_feldman/feldmannwbconverter.py
+++ b/feldman_lab_to_nwb/convert_feldman/feldmannwbconverter.py
@@ -6,7 +6,7 @@ from spikeextractors import SpikeGLXRecordingExtractor
 from nwb_conversion_tools import NWBConverter, SpikeGLXRecordingInterface, SpikeGLXLFPInterface
 
 from .feldmanbehaviordatainterface import FeldmanBehaviorDataInterface
-from .feldman_utils import get_trials_info, clip_recording
+from .utils import get_trials_info, clip_recording
 
 
 class FeldmanNWBConverter(NWBConverter):
@@ -37,6 +37,9 @@ class FeldmanNWBConverter(NWBConverter):
                     trial_numbers=trial_numbers,
                     trial_times=trial_times,
                     recording=self.data_interface_objects[interface].recording_extractor
+                )
+                self.data_interface_objects[interface].recording_extractor.set_channel_gains = (
+                    self.data_interface_objects[interface].recording_extractor._parent_recording.get_channel_gains()
                 )
 
     def get_metadata(self):

--- a/feldman_lab_to_nwb/convert_feldman/feldmannwbconverter.py
+++ b/feldman_lab_to_nwb/convert_feldman/feldmannwbconverter.py
@@ -1,5 +1,6 @@
 """Authors: Cody Baker."""
 from pathlib import Path
+from pandas import read_csv
 
 from spikeextractors import SpikeGLXRecordingExtractor
 from nwb_conversion_tools import NWBConverter, SpikeGLXRecordingInterface, SpikeGLXLFPInterface
@@ -44,4 +45,15 @@ class FeldmanNWBConverter(NWBConverter):
         metadata["NWBFile"].update(institution="UC Berkeley", lab="Feldman")
         if "session_id" not in metadata["NWBFile"]:
             metadata["NWBFile"].update(session_id="_".join(next(behavior_folder_path.iterdir()).stem.split("_")[:3]))
+
+        header_segments = [x for x in behavior_folder_path.iterdir() if "header" in x.name]
+        first_header = read_csv(header_segments[0], header=None, sep="\t", index_col=0).T
+        metadata["NWBFile"].update(
+            session_description=str(
+                dict(
+                    text_description=metadata["NWBFile"]["session_description"],
+                    header_info={x: y.values[0] for x, y in first_header.items()}
+                )
+            ).replace("'", "\"")
+        )
         return metadata

--- a/feldman_lab_to_nwb/convert_feldman/rapidtestingdatainterface.py
+++ b/feldman_lab_to_nwb/convert_feldman/rapidtestingdatainterface.py
@@ -6,7 +6,7 @@ from nwb_conversion_tools import SpikeGLXRecordingInterface
 from pynwb import NWBFile
 from spikeextractors import NwbRecordingExtractor, SpikeGLXRecordingExtractor
 
-from .feldman_utils import get_trials_info
+from .utils import get_trials_info
 
 
 def infer_ap_filepath(nidq_file_path: str):

--- a/feldman_lab_to_nwb/convert_feldman/utils.py
+++ b/feldman_lab_to_nwb/convert_feldman/utils.py
@@ -140,7 +140,7 @@ def clip_recording(
     trial_numbers: Iterable,
     trial_times: Iterable,
     recording: RecordingExtractor = None
-) -> RecordingExtractor:
+) -> SubRecordingExtractor:
     """
     Clip the recording to align with the trials information.
 

--- a/notebooks/parse-nidq-signals.ipynb
+++ b/notebooks/parse-nidq-signals.ipynb
@@ -25,7 +25,7 @@
     "import spikecomparison as sc\n",
     "import spikewidgets as sw\n",
     "\n",
-    "from feldman_lab_to_nwb.convert_feldman.feldman_utils import get_trials_info\n",
+    "from feldman_lab_to_nwb.convert_feldman.utils import get_trials_info\n",
     "\n",
     "%matplotlib notebook"
    ]
@@ -559,7 +559,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.9"
+   "version": "3.9.1"
   },
   "pycharm": {
    "stem_cell": {

--- a/notebooks/processing_pipeline.ipynb
+++ b/notebooks/processing_pipeline.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -66,7 +66,8 @@
    "source": [
     "recording_folder = Path(\".\")\n",
     "spikeinterface_folder = recording_folder / \"spikeinterface\"\n",
-    "spikeinterface_folder.mkdir(parents=True, exist_ok=True)"
+    "spikeinterface_folder.mkdir(parents=True, exist_ok=True)\n",
+    "units_description = dict()"
    ]
   },
   {
@@ -149,7 +150,14 @@
    "outputs": [],
    "source": [
     "apply_bandpass = True\n",
-    "apply_cmr = True"
+    "apply_cmr = True\n",
+    "\n",
+    "bandpass_parameters = dict(\n",
+    "    freq_min=300,\n",
+    "    freq_max=6000,\n",
+    "    freq_wid=1000,\n",
+    "    filter_type=\"fft\"\n",
+    ")"
    ]
   },
   {
@@ -159,7 +167,8 @@
    "outputs": [],
    "source": [
     "if apply_bandpass:\n",
-    "    recording_processed = st.preprocessing.bandpass_filter(recording_ap)\n",
+    "    recording_processed = st.preprocessing.bandpass_filter(recording_ap, **bandpass_parameters)\n",
+    "    units_description.update(filter_parameters=bandpass_parameters)\n",
     "else:\n",
     "    recording_processed = recording_ap\n",
     "\n",
@@ -261,13 +270,14 @@
    "outputs": [],
    "source": [
     "# user-specific parameters\n",
-    "sorter_params = dict(\n",
+    "sorter_parameters = dict(\n",
     "    #kilosort2=dict(car=False, n_jobs_bin=12, chunk_mb=4000),\n",
     "    ironclust=dict(n_jobs_bin=6, chunk_mb=6000),\n",
     "    #tridesclous=dict(n_jobs_bin=12, chunk_mb=4000),\n",
     "    #spykingcircus=dict(filter=True, num_workers=16),\n",
     "    #herdingspikes=dict(filter=True)\n",
-    ")"
+    ")\n",
+    "units_description.update(sorter_parameters=sorter_parameters)"
    ]
   },
   {
@@ -689,7 +699,8 @@
     "    sorting=chosen_sorting_extractor,\n",
     "    save_path=nwbfile_path,\n",
     "    overwrite=False,  # this appends the file. True would write a new file\n",
-    "    skip_features=[\"waveforms\"]\n",
+    "    skip_features=[\"waveforms\"],\n",
+    "    units_description=str(units_description).replace(\"'\", \"\\\"\")\n",
     ")"
    ]
   },

--- a/notebooks/processing_pipeline.ipynb
+++ b/notebooks/processing_pipeline.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -17,12 +17,16 @@
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
     "from pprint import pprint\n",
+    "import json\n",
     "\n",
     "import spikeextractors as se\n",
     "import spiketoolkit as st\n",
     "import spikesorters as ss\n",
     "import spikecomparison as sc\n",
     "import spikewidgets as sw\n",
+    "from nwb_conversion_tools.utils.spike_interface import write_sorting\n",
+    "\n",
+    "from feldman_lab_to_nwb.convert_feldman.utils import get_trials_info, clip_recording\n",
     "\n",
     "%matplotlib notebook"
    ]
@@ -40,15 +44,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "base_path = Path(\"E:/Feldman/Neuropixels_Feldman/210209/SpikeGLX\")\n",
-    "session_name = \"LR_210209_g0\"\n",
+    "base_path = Path(\"E:/Feldman\")\n",
     "\n",
-    "ap_bin_path = base_path / session_name / f\"{session_name}_imec0\" / f\"{session_name}_t0.imec0.ap.bin\"\n",
-    "lf_bin_path = base_path / session_name / f\"{session_name}_imec0\" / f\"{session_name}_t0.imec0.lf.bin\"\n",
-    "nidq_file_path = base_path / session_name / f\"{session_name}_t0.nidq.bin\"\n",
-    "\n",
-    "# Path to NWBFile, possibly one that already contains behavioral data for the session\n",
-    "nwbfile_path = f\"E:/Feldman/{session_name}.nwb\""
+    "# Point to the various files for the conversion\n",
+    "session_date = \"210406\"  # YYMMDD\n",
+    "experiment_folder = base_path / \"Neuropixels_Feldman\" / f\"{session_date}\"\n",
+    "sess_name = f\"LR_{session_date}_g0\"\n",
+    "ap_bin_path = (\n",
+    "    experiment_folder / \"SpikeGLX\" / sess_name/ f\"{sess_name}_imec0\" / f\"{sess_name}_t0.imec0.ap.bin\"\n",
+    ")\n",
+    "lf_bin_path = ap_bin_path.parent / ap_bin_path.name.replace(\"ap\", \"lf\")\n",
+    "nidq_synch_file = str(experiment_folder / \"SpikeGLX\" / sess_name / f\"{sess_name}_t0.nidq.bin\")"
    ]
   },
   {
@@ -64,10 +70,39 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "recording_folder = Path(\".\")\n",
+    "recording_folder = experiment_folder\n",
     "spikeinterface_folder = recording_folder / \"spikeinterface\"\n",
     "spikeinterface_folder.mkdir(parents=True, exist_ok=True)\n",
     "units_description = dict()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Synchronize recording times with trials"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "recording_ap = se.SpikeGLXRecordingExtractor(ap_bin_path)\n",
+    "recording_lf = se.SpikeGLXRecordingExtractor(lf_bin_path)\n",
+    "\n",
+    "trial_ongoing_channel = 2\n",
+    "event_channel = 3\n",
+    "\n",
+    "trial_numbers, _, trial_times = get_trials_info(\n",
+    "    recording_nidq=se.SpikeGLXRecordingExtractor(nidq_synch_file),\n",
+    "    trial_ongoing_channel=trial_ongoing_channel,\n",
+    "    event_channel=event_channel\n",
+    ")\n",
+    "if trial_numbers[0] != 0:\n",
+    "    recording_ap = clip_recording(trial_numbers=trial_numbers, trial_times=trial_times, recording=recording_ap)\n",
+    "    recording_lf = clip_recording(trial_numbers=trial_numbers, trial_times=trial_times, recording=recording_lf)"
    ]
   },
   {
@@ -84,17 +119,7 @@
    "outputs": [],
    "source": [
     "stub_test = True\n",
-    "nsec_stub = 30"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "recording_ap = se.SpikeGLXRecordingExtractor(ap_bin_path)\n",
-    "recording_lf = se.SpikeGLXRecordingExtractor(lf_bin_path)\n",
+    "nsec_stub = 30\n",
     "\n",
     "if stub_test:\n",
     "    recording_ap = se.SubRecordingExtractor(recording_ap, end_frame=int(nsec_stub*recording_ap.get_sampling_frequency()))\n",
@@ -115,29 +140,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Synchronize recording times with trials"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "trial_numbers, _, trial_times = get_trials_info(\n",
-    "    recording_nidq=SpikeGLXRecordingExtractor(nidq_synch_file),\n",
-    "    trial_ongoing_channel=trial_ongoing_channel,\n",
-    "    event_channel=event_channel\n",
-    ")\n",
-    "if trial_numbers[0] != 0:\n",
-    "    recording_ap = clip_recording(trial_numbers=trial_numbers, trial_times=trial_times, recording=recording_ap)\n",
-    "    recording_lf = clip_recording(trial_numbers=trial_numbers, trial_times=trial_times, recording=recording_lf)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "### Inspect signals"
    ]
   },
@@ -147,7 +149,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "w_ts_ap = sw.plot_timeseries(recording_ap, channel_ids=recording_ap.get_channel_ids()[::4], trange=[0, 5])"
+    "w_ts_ap = sw.plot_timeseries(recording_ap, channel_ids=recording_ap.get_channel_ids()[::4], trange=[0, 1])"
    ]
   },
   {
@@ -199,15 +201,6 @@
     "    recording_processed = st.preprocessing.common_reference(recording_processed)\n",
     "else:\n",
     "    recording_processed = recording_processed"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "num_frames = recording_processed.get_num_frames()"
    ]
   },
   {
@@ -279,11 +272,13 @@
    "outputs": [],
    "source": [
     "# Inspect sorter-specific parameters and defaults\n",
+    "sorter_parameters = dict()\n",
     "for sorter in sorter_list:\n",
     "    print(f\"{sorter} params description:\")\n",
     "    pprint(ss.get_params_description(sorter))\n",
     "    print(\"Default params:\")\n",
-    "    pprint(ss.get_default_params(sorter))    "
+    "    sorter_parameters[sorter] = ss.get_default_params(sorter)\n",
+    "    pprint(sorter_parameters[sorter])"
    ]
   },
   {
@@ -293,12 +288,9 @@
    "outputs": [],
    "source": [
     "# user-specific parameters\n",
-    "sorter_parameters = dict(\n",
-    "    #kilosort2=dict(car=False, n_jobs_bin=12, chunk_mb=4000),\n",
-    "    ironclust=dict(n_jobs_bin=6, chunk_mb=6000),\n",
-    "    #tridesclous=dict(n_jobs_bin=12, chunk_mb=4000),\n",
-    "    #spykingcircus=dict(filter=True, num_workers=16),\n",
-    "    #herdingspikes=dict(filter=True)\n",
+    "sorter_parameters[\"ironclust\"].update(\n",
+    "    n_jobs_bin=6,\n",
+    "    chunk_mb=6000\n",
     ")\n",
     "units_description.update(sorter_parameters=sorter_parameters)"
    ]
@@ -314,7 +306,7 @@
     "    recording_dict_or_list=dict(rec0=recording_processed),\n",
     "    working_folder=spikeinterface_folder / \"working1\",\n",
     "    mode=\"keep\", # change to \"keep\" to avoid repeating the spike sorting\n",
-    "    sorter_params=sorter_params,\n",
+    "    sorter_params=sorter_parameters,\n",
     "    verbose=True,\n",
     "    run_sorter_kwargs=dict(raise_error=False)\n",
     ")"
@@ -715,15 +707,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Path to NWBFile, possibly one that already contains behavioral data for the session\n",
+    "nwbfile_path = base_path / \"LR_210406_g0_full_pipeline_stub_test.nwb\"\n",
+    "\n",
     "# Choose the sorting extractor from the notebook environment you would like to write to NWB\n",
     "chosen_sorting_extractor = sorting_outputs[(\"rec0\", \"ironclust\")]\n",
     "\n",
-    "se.NwbSortingExtractor.write_sorting(\n",
+    "write_sorting(\n",
     "    sorting=chosen_sorting_extractor,\n",
     "    save_path=nwbfile_path,\n",
     "    overwrite=False,  # this appends the file. True would write a new file\n",
     "    skip_features=[\"waveforms\"],\n",
-    "    units_description=str(units_description).replace(\"'\", \"\\\"\")\n",
+    "    units_description=json.dumps(units_description)\n",
     ")"
    ]
   },
@@ -751,7 +746,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.9.1"
   },
   "pycharm": {
    "stem_cell": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ jupyter==1.0.0
 pynwb==1.4.0
 h5py==2.10.0
 isodate==0.6.0
-git+https://github.com/catalystneuro/nwb-conversion-tools
-git+https://github.com/NeurodataWithoutBorders/nwb-jupyter-widgets
+nwb-conversion-tools @ git+https://github.com/catalystneuro/nwb-conversion-tools.git@e8ff6dc7d74235a5c909e071ec3cc2005b694ea5
+nwbwidgets @ git+https://github.com/NeurodataWithoutBorders/nwb-jupyter-widgets@6b2dd8d5a811e97c3c0ce2c40c905ff694d32ecc
 ndx_events==0.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ jupyter==1.0.0
 pynwb==1.4.0
 h5py==2.10.0
 isodate==0.6.0
-nwb-conversion-tools @ git+https://github.com/catalystneuro/nwb-conversion-tools.git@e8ff6dc7d74235a5c909e071ec3cc2005b694ea5
+nwb-conversion-tools @ git+https://github.com/catalystneuro/nwb-conversion-tools.git@3f4d2c4a90e1cb9dabe72940104835f3d67fd889
 nwbwidgets @ git+https://github.com/NeurodataWithoutBorders/nwb-jupyter-widgets@6b2dd8d5a811e97c3c0ce2c40c905ff694d32ecc
 ndx_events==0.2.0

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,11 @@
 # -*- coding: utf-8 -*-
 from setuptools import setup, find_packages
+import os
 
 with open("README.md", "r") as f:
     long_description = f.read()
+with open(os.path.join(os.path.abspath(os.path.dirname(__file__)), "requirements.txt")) as f:
+    install_requires = f.read().strip().split("\n")
 setup(
     name="feldman_lab_to_nwb",
     version="0.0.1",
@@ -13,8 +16,5 @@ setup(
     email="ben.dichter@catalystneuro.com",
     packages=find_packages(),
     include_package_data=True,
-    install_requires=[
-        "matplotlib", "scipy", "hdf5storage", "jupyter", "xlrd", "h5py", "pynwb", "spikeinterface", "nwbwidgets",
-        "nwb-conversion-tools", "ndx_events"
-    ],
+    install_requires=install_requires,
 )


### PR DESCRIPTION
@bendichter Inherits from PR #17, in order to fully test the writing of the data to the spike.mat format with the synching corrected.

This code finishes the final aim from the scope - there may be a couple small bugs to fix down the road in terms of the exact data typing of each nested struct in the written .mat file for each stimulus layout. But what is output here looks almost exact for the fields we have access too from the behavioral csv's and the spike interface processing pipeline.